### PR TITLE
Trust Onboard SDK now depends on Azure, add this to the build process

### DIFF
--- a/cross-build.sh
+++ b/cross-build.sh
@@ -32,7 +32,7 @@ for prod in $products; do
 			;;
 		"breakout-tob-sdk")
 			cp lib/cross-build-trust-onboard.sh ${ROOTDIR}
-			chroot ${ROOTDIR} /cross-build-trust-onboard.sh https://github.com/twilio/Breakout_Trust_Onboard_SDK ${prodbranch} ${prodver} ${dist} -DOPENSSL_SUPPORT=ON -DBUILD_SHARED=ON >&2
+			chroot ${ROOTDIR} /cross-build-trust-onboard.sh https://github.com/twilio/Breakout_Trust_Onboard_SDK ${prodbranch} ${prodver} ${dist} -DOPENSSL_SUPPORT=ON -DBUILD_AZURE=ON >&2
 			;;
 		*)
 			echo "Unknown product, skipping" >&2

--- a/lib/cross-build-trust-onboard.sh
+++ b/lib/cross-build-trust-onboard.sh
@@ -9,7 +9,7 @@ dist=$4
 # the rest are cmake flags
 cmake_flags=${@:5}
 
-echo "CMAKE FLAGS are ${cmake_flags}"
+apt install azure-iot-sdk-c-twilio nlohmann-json-dev
 
 mkdir -p /debs
 cd /debs

--- a/lib/debootstrap-rpi.sh
+++ b/lib/debootstrap-rpi.sh
@@ -5,8 +5,7 @@ set -e
 rootfs=$1
 dist=$2
 mirror="http://archive.raspbian.org/raspbian"
-include="fakeroot,build-essential,ca-certificates,git,cmake,dh-make,uuid-dev,libssl-dev,libcurl4-openssl-dev,curl,clang"
-
+include="fakeroot,build-essential,ca-certificates,git,cmake,dh-make,uuid-dev,libssl-dev,libcurl4-openssl-dev,curl,clang,dirmngr"
 
 if [ "$rootfs" == "" ]; then
 	rootfs=$(realpath ./deboootstrap-rootfs)
@@ -21,7 +20,7 @@ if [ $EUID -ne 0 ]; then
 	exit 1
 fi
 
-aptsources="deb http://archive.raspbian.org/raspbian ${dist} main contrib non-free\ndeb-src http://archive.raspbian.org/raspbian ${dist} main contrib non-free"
+aptsources="deb http://archive.raspbian.org/raspbian ${dist} main contrib non-free\ndeb-src http://archive.raspbian.org/raspbian ${dist} main contrib non-free\ndeb http://twilio.bintray.com/wireless ${dist} main"
 
 to_install="debootstrap qemu-user-static"
 
@@ -36,4 +35,5 @@ cp /usr/bin/qemu-arm-static $rootfs/usr/bin
 chroot $rootfs /debootstrap/debootstrap --second-stage
 echo -e $aptsources > $rootfs/etc/apt/sources.list
 
+chroot $rootfs apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
 chroot $rootfs apt update


### PR DESCRIPTION
The dependency is being pulled from Bintray. On a (rare) occasion when Trust Onboard SDK depends on Azure SDK being updated, the latter should be released first.