### PR TITLE
Fix builds for stretch

### DIFF
--- a/lib/cross-build-deb-azure.sh
+++ b/lib/cross-build-deb-azure.sh
@@ -45,6 +45,10 @@ azure-iot-sdk-c-twilio (${version}.1${dist}) ${dist}; urgency=low
  -- Anton Gerasimov <agerasimov@twilio.com> $(date -R)
 EOF
 
+if [ "$dist" == "stretch" ]; then
+	sed -i -e 's/libssl-dev/libssl1.0-dev' ./debian/control
+fi
+
 dpkg-buildpackage -us -uc || fail "Building debian package failed"
 
 # do we need a source package?

--- a/lib/cross-build-trust-onboard.sh
+++ b/lib/cross-build-trust-onboard.sh
@@ -9,7 +9,7 @@ dist=$4
 # the rest are cmake flags
 cmake_flags=${@:5}
 
-apt install azure-iot-sdk-c-twilio nlohmann-json-dev
+apt-get -y install azure-iot-sdk-c-twilio-dev nlohmann-json-dev
 
 mkdir -p /debs
 cd /debs

--- a/lib/debootstrap-rpi.sh
+++ b/lib/debootstrap-rpi.sh
@@ -5,7 +5,13 @@ set -e
 rootfs=$1
 dist=$2
 mirror="http://archive.raspbian.org/raspbian"
-include="fakeroot,build-essential,ca-certificates,git,cmake,dh-make,uuid-dev,libssl-dev,libcurl4-openssl-dev,curl,clang,dirmngr"
+include="fakeroot,build-essential,ca-certificates,git,cmake,dh-make,uuid-dev,libcurl4-openssl-dev,curl,clang,dirmngr"
+
+if [ "$dist" == "stretch" ]; then
+	include="${include},libssl1.0-dev"
+else
+	include="${include},libssl-dev"
+fi
 
 if [ "$rootfs" == "" ]; then
 	rootfs=$(realpath ./deboootstrap-rootfs)


### PR DESCRIPTION
  * Pulling libssl1.1 headers created conflicts between libcurl and
built libraries/samples, remove them
  * Same thing with having these headers as a dependency for Azure IoT
SDK

Signed-off-by: Anton Gerasimov <agerasimov@twilio.com>
